### PR TITLE
Help command: launch a separate window

### DIFF
--- a/src/main/java/duke/command/HelpCommand.java
+++ b/src/main/java/duke/command/HelpCommand.java
@@ -3,6 +3,7 @@ package duke.command;
 import duke.Storage;
 import duke.TaskList;
 import duke.gui.GuiText;
+import duke.gui.HelpWindow;
 import duke.gui.MainWindow;
 import duke.gui.SpriteEmotion;
 
@@ -14,8 +15,16 @@ public class HelpCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, GuiText guiText, Storage storage) {
-        MainWindow.changeSpriteExpression(SpriteEmotion.NEUTRAL);
-        return guiText.showHelp();
+        boolean isHelpWindowOpen = HelpWindow.isOpen();
+
+        if (!isHelpWindowOpen) {
+            MainWindow.changeSpriteExpression(SpriteEmotion.HAPPY);
+            HelpWindow.launchHelpWindow();
+        } else {
+            MainWindow.changeSpriteExpression(SpriteEmotion.SURPRISED);
+        }
+
+        return GuiText.showHelp(isHelpWindowOpen);
     }
 
 }

--- a/src/main/java/duke/gui/Gui.java
+++ b/src/main/java/duke/gui/Gui.java
@@ -21,6 +21,10 @@ public class Gui extends Application {
             AnchorPane ap = fxmlLoader.load();
             Scene scene = new Scene(ap);
             stage.setScene(scene);
+            stage.setTitle("Colette");
+            stage.setOnCloseRequest(event ->
+                HelpWindow.closeHelpWindow()
+            );
             fxmlLoader.<MainWindow>getController().setStage(stage);
             stage.show();
         } catch (IOException e) {

--- a/src/main/java/duke/gui/GuiText.java
+++ b/src/main/java/duke/gui/GuiText.java
@@ -238,10 +238,27 @@ public class GuiText {
         return isSuccessful ? "Tasks successfully loaded from storage!" : "Loading from storage failed.";
     }
 
-    public String showHelp() {
+    /**
+     * Generates the text to put in the separate
+     * help window.
+     *
+     * @return Text to put in the separate help window.
+     */
+    public static String generateHelpWindowText() {
         String acceptedCommands = "Here are all the commands that I accept!\n"
                 + "\n";
         return acceptedCommands + CommandType.getAllCommandFormatString();
+    }
+
+    /**
+     * Returns the text to show when
+     * user uses the help command.
+     *
+     * @param isHelpWindowOpen Whether the help window is already open.
+     * @return Text to show.
+     */
+    public static String showHelp(boolean isHelpWindowOpen) {
+        return !isHelpWindowOpen ? "The help window has been opened!" : "The help window is already open!";
     }
 
 }

--- a/src/main/java/duke/gui/HelpWindow.java
+++ b/src/main/java/duke/gui/HelpWindow.java
@@ -1,0 +1,62 @@
+package duke.gui;
+
+import java.io.IOException;
+
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+/** Class that handles the separate help window of the GUI */
+public class HelpWindow extends AnchorPane {
+
+    private static boolean isOpen = false;
+    private static Stage stage;
+
+    @FXML
+    private Text helpText;
+
+    @FXML
+    public void initialize() {
+        this.helpText.setText(GuiText.generateHelpWindowText());
+        HelpWindow.isOpen = true;
+    }
+
+    /**
+     * Launches the help window if it is not already open.
+     */
+    public static void launchHelpWindow() {
+        try {
+            FXMLLoader fxmlLoader = new FXMLLoader(Gui.class
+                    .getResource("../resources/view/HelpWindow.fxml"));
+            AnchorPane ap = fxmlLoader.load();
+            Scene scene = new Scene(ap);
+            Stage stage = new Stage();
+            HelpWindow.stage = stage;
+            stage.setTitle("Help");
+            stage.setScene(scene);
+            stage.setOnCloseRequest(event ->
+                HelpWindow.isOpen = false
+            );
+            stage.show();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Closes the help window if it is open.
+     */
+    public static void closeHelpWindow() {
+        if (HelpWindow.isOpen) {
+            HelpWindow.stage.close();
+        }
+    }
+
+    public static boolean isOpen() {
+        return HelpWindow.isOpen;
+    }
+
+}

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -78,6 +78,7 @@ public class MainWindow extends AnchorPane {
         if (this.duke.isExit()) {
             userInput.setDisable(true);
             sendButton.setDisable(true);
+            HelpWindow.closeHelpWindow();
             PauseTransition delay = new PauseTransition(Duration.seconds(MainWindow.exitDelayTimeInSeconds));
             delay.setOnFinished( event -> this.stage.close() );
             delay.play();

--- a/src/main/java/duke/resources/view/HelpWindow.fxml
+++ b/src/main/java/duke/resources/view/HelpWindow.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.text.Text?>
+
+<AnchorPane prefHeight="400.0" prefWidth="400.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="duke.gui.HelpWindow">
+    <children>
+        <StackPane prefWidth="250.0" maxWidth="250.0" maxHeight="Infinity">
+            <Text fx:id="helpText" text="label" textAlignment="center" style="-fx-font-family: Lucida Grande; -fx-font-size: 20;"/>
+        </StackPane>
+    </children>
+</AnchorPane>


### PR DESCRIPTION
When a help command is issued, Duke outputs a long response containing all commands it recognises.

This is hard to read due to the text being longer than the window length, and needing the user to scroll up and down to find the command they want to execute.

Let's add a separate window to contain all the commands that Duke recognises, and launch this window when a help command is issued.

TODO:
* Improve the GUI of the help window